### PR TITLE
Add project README and license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,35 @@
+# Programmieren 2 – C/C++ Lernmaterial
+
+Dieses Repository enthält HTML-Präsentationen und Übungsunterlagen für die Vorlesung *Programmieren 2*. Die Kapitel vermitteln Schritt für Schritt die Grundlagen der Programmiersprachen **C** und **C++**.
+
+## Projektstruktur
+- `index.html` – Startseite mit Links zu allen Kapiteln
+- `c/` und `cpp/` – HTML-Slides für C bzw. C++
+- `material/` – PDF-Skripte und Übungsblätter (siehe unten)
+- `style.css` – gemeinsames Layout
+
+## Lokales Öffnen von `index.html`
+Die einfachste Variante ist, `index.html` im Browser zu öffnen (Doppelklick oder per `Datei > Öffnen`). Alternativ lässt sich ein lokaler HTTP-Server nutzen:
+
+```bash
+# Python 3
+python3 -m http.server
+```
+
+Anschließend kann `http://localhost:8000/index.html` im Browser aufgerufen werden. In Visual Studio Code bietet sich auch die Erweiterung *Live Server* (Port 5501) an.
+
+## Materialien (`material/`)
+Im Ordner `material/` befinden sich ausführliche Skripte zu jeder Vorlesungseinheit sowie Übungsaufgaben für **C** und **C++**. Zum Betrachten wird lediglich ein PDF-Reader benötigt. Für die praktischen Aufgaben sollte eine aktuelle C/C++-Entwicklungsumgebung (z.B. GCC oder clang) installiert sein.
+
+## Optionale Werkzeuge
+Um die HTML-Dateien komfortabel zu nutzen, kann ein lokaler Webserver hilfreich sein. Unter Python steht `http.server` standardmäßig zur Verfügung. Unter Node.js eignet sich das Paket `http-server`:
+
+```bash
+npm install -g http-server
+http-server -p 8000
+```
+
+Das Repository enthält keine Abhängigkeiten und benötigt auch keine Build-Schritte.
+
+## Lizenz
+Der Inhalt dieses Repositories steht unter der [MIT-Lizenz](LICENSE).


### PR DESCRIPTION
## Summary
- document project structure and usage in README
- provide instructions for opening `index.html` and optional local web server
- describe PDF material and prerequisites
- add MIT license

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_685935af1ad0832fae16c94a7cc6bbab