### PR TITLE
Improve site style and add navigation

### DIFF
--- a/c/01_Einfuehrung_Datentypen_Variablen.html
+++ b/c/01_Einfuehrung_Datentypen_Variablen.html
@@ -4,9 +4,17 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Kapitel 1: Einführung in C</title>
+    <link rel="preconnect" href="https://fonts.gstatic.com">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="../style.css">
 </head>
 <body>
+<nav id="main-nav">
+    <a href="../index.html">Start</a>
+    <a href="index.html">C</a>
+    <a href="../cpp/index.html">C++</a>
+    <a href="../material/">Materialien</a>
+</nav>
 
     <header>
         <h1>Kapitel 1: Einführung in C: Datentypen, Variablen & Konstanten</h1>

--- a/c/02_Operatoren_und_formatierte_IO.html
+++ b/c/02_Operatoren_und_formatierte_IO.html
@@ -4,9 +4,17 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Kapitel 2: Operatoren und I/O</title>
+    <link rel="preconnect" href="https://fonts.gstatic.com">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="../style.css">
 </head>
 <body>
+<nav id="main-nav">
+    <a href="../index.html">Start</a>
+    <a href="index.html">C</a>
+    <a href="../cpp/index.html">C++</a>
+    <a href="../material/">Materialien</a>
+</nav>
 
     <header>
         <h1>Kapitel 2: Operatoren und formatierte Ein-/Ausgabe</h1>

--- a/c/03_Funktionen_Struktur.html
+++ b/c/03_Funktionen_Struktur.html
@@ -4,9 +4,17 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Kapitel 3: Funktionen</title>
+    <link rel="preconnect" href="https://fonts.gstatic.com">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="../style.css">
 </head>
 <body>
+<nav id="main-nav">
+    <a href="../index.html">Start</a>
+    <a href="index.html">C</a>
+    <a href="../cpp/index.html">C++</a>
+    <a href="../material/">Materialien</a>
+</nav>
 
     <header>
         <h1>Kapitel 3: Funktionen: Struktur, Gültigkeit & Wiederverwendung</h1>

--- a/c/04_Kontrollstrukturen_Logik.html
+++ b/c/04_Kontrollstrukturen_Logik.html
@@ -4,9 +4,17 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Kapitel 4: Kontrollstrukturen</title>
+    <link rel="preconnect" href="https://fonts.gstatic.com">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="../style.css">
 </head>
 <body>
+<nav id="main-nav">
+    <a href="../index.html">Start</a>
+    <a href="index.html">C</a>
+    <a href="../cpp/index.html">C++</a>
+    <a href="../material/">Materialien</a>
+</nav>
 
     <header>
         <h1>Kapitel 4: Kontrollstrukturen: Logik, Schleifen & Rekursion</h1>

--- a/c/05_Komplexe_Datentypen.html
+++ b/c/05_Komplexe_Datentypen.html
@@ -4,9 +4,17 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Kapitel 5: Komplexe Datentypen</title>
+    <link rel="preconnect" href="https://fonts.gstatic.com">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="../style.css">
 </head>
 <body>
+<nav id="main-nav">
+    <a href="../index.html">Start</a>
+    <a href="index.html">C</a>
+    <a href="../cpp/index.html">C++</a>
+    <a href="../material/">Materialien</a>
+</nav>
 
     <header>
         <h1>Kapitel 5: Komplexe Datentypen: Arrays, Structs & Enums</h1>

--- a/c/06_Zeiger_Grundlagen.html
+++ b/c/06_Zeiger_Grundlagen.html
@@ -4,9 +4,17 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Kapitel 6: Zeiger (Teil 1)</title>
+    <link rel="preconnect" href="https://fonts.gstatic.com">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="../style.css">
 </head>
 <body>
+<nav id="main-nav">
+    <a href="../index.html">Start</a>
+    <a href="index.html">C</a>
+    <a href="../cpp/index.html">C++</a>
+    <a href="../material/">Materialien</a>
+</nav>
 
     <header>
         <h1>Kapitel 6: Zeiger (Teil 1) - Adressen und Referenzen</h1>

--- a/c/07_Zeiger.Arithmetik_Dynamik.html
+++ b/c/07_Zeiger.Arithmetik_Dynamik.html
@@ -4,9 +4,17 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Kapitel 7: Zeiger (Teil 2)</title>
+    <link rel="preconnect" href="https://fonts.gstatic.com">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="../style.css">
 </head>
 <body>
+<nav id="main-nav">
+    <a href="../index.html">Start</a>
+    <a href="index.html">C</a>
+    <a href="../cpp/index.html">C++</a>
+    <a href="../material/">Materialien</a>
+</nav>
 
     <header>
         <h1>Kapitel 7: Zeiger (Teil 2) - Zeigerarithmetik & Dynamischer Speicher</h1>

--- a/c/08_Zeiger_Fortgeschritten.html
+++ b/c/08_Zeiger_Fortgeschritten.html
@@ -4,9 +4,17 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Kapitel 8: Zeiger (Teil 3)</title>
+    <link rel="preconnect" href="https://fonts.gstatic.com">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="../style.css">
 </head>
 <body>
+<nav id="main-nav">
+    <a href="../index.html">Start</a>
+    <a href="index.html">C</a>
+    <a href="../cpp/index.html">C++</a>
+    <a href="../material/">Materialien</a>
+</nav>
 
     <header>
         <h1>Kapitel 8: Zeiger (Teil 3) - Zeiger auf Zeiger & Funktionszeiger</h1>

--- a/c/09_Dateiverwaltung_Praeprozessor.html
+++ b/c/09_Dateiverwaltung_Praeprozessor.html
@@ -4,9 +4,17 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Kapitel 9: Dateiverarbeitung und Präprozessor</title>
+    <link rel="preconnect" href="https://fonts.gstatic.com">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="../style.css">
 </head>
 <body>
+<nav id="main-nav">
+    <a href="../index.html">Start</a>
+    <a href="index.html">C</a>
+    <a href="../cpp/index.html">C++</a>
+    <a href="../material/">Materialien</a>
+</nav>
 
     <header>
         <h1>Kapitel 9: Dateiverarbeitung und Präprozessor</h1>

--- a/c/10_Modulare_Programmierung_Kommandozeile.html
+++ b/c/10_Modulare_Programmierung_Kommandozeile.html
@@ -4,9 +4,17 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Kapitel 10: Modulare Programmierung</title>
+    <link rel="preconnect" href="https://fonts.gstatic.com">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="../style.css">
 </head>
 <body>
+<nav id="main-nav">
+    <a href="../index.html">Start</a>
+    <a href="index.html">C</a>
+    <a href="../cpp/index.html">C++</a>
+    <a href="../material/">Materialien</a>
+</nav>
 
     <header>
         <h1>Kapitel 10: Modulare Programmierung & Kommandozeilenparameter</h1>

--- a/c/11_Die_C-Standardbibliothek.html
+++ b/c/11_Die_C-Standardbibliothek.html
@@ -4,9 +4,17 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Kapitel 11: Die C-Standardbibliothek</title>
+    <link rel="preconnect" href="https://fonts.gstatic.com">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="../style.css">
 </head>
 <body>
+<nav id="main-nav">
+    <a href="../index.html">Start</a>
+    <a href="index.html">C</a>
+    <a href="../cpp/index.html">C++</a>
+    <a href="../material/">Materialien</a>
+</nav>
 
     <header>
         <h1>Kapitel 11: Die C-Standardbibliothek</h1>

--- a/c/12_Threads.html
+++ b/c/12_Threads.html
@@ -4,9 +4,17 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Kapitel 12: Parallele Programmierung</title>
+    <link rel="preconnect" href="https://fonts.gstatic.com">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="../style.css">
 </head>
 <body>
+<nav id="main-nav">
+    <a href="../index.html">Start</a>
+    <a href="index.html">C</a>
+    <a href="../cpp/index.html">C++</a>
+    <a href="../material/">Materialien</a>
+</nav>
 
     <header>
         <h1>Kapitel 12: Einführung in die Parallele Programmierung mit Threads</h1>

--- a/c/13_Problemloesung_und_Tipps.html
+++ b/c/13_Problemloesung_und_Tipps.html
@@ -4,9 +4,17 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Kapitel 13: Fortgeschrittene Problemlösung</title>
+    <link rel="preconnect" href="https://fonts.gstatic.com">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="../style.css">
 </head>
 <body>
+<nav id="main-nav">
+    <a href="../index.html">Start</a>
+    <a href="index.html">C</a>
+    <a href="../cpp/index.html">C++</a>
+    <a href="../material/">Materialien</a>
+</nav>
 
     <header>
         <h1>Kapitel 13: Fortgeschrittene Problemlösung & Praktische Tipps</h1>

--- a/c/index.html
+++ b/c/index.html
@@ -4,9 +4,19 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>C Kapitel</title>
+    <link rel="preconnect" href="https://fonts.gstatic.com">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+    <link rel="preconnect" href="https://fonts.gstatic.com">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="../style.css">
 </head>
 <body>
+<nav id="main-nav">
+    <a href="../index.html">Start</a>
+    <a href="index.html">C</a>
+    <a href="../cpp/index.html">C++</a>
+    <a href="../material/">Materialien</a>
+</nav>
 <header>
     <h1>C Kapitel</h1>
 </header>

--- a/cpp/index.html
+++ b/cpp/index.html
@@ -4,9 +4,17 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>C++ Kapitel</title>
+    <link rel="preconnect" href="https://fonts.gstatic.com">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="../style.css">
 </head>
 <body>
+<nav id="main-nav">
+    <a href="../index.html">Start</a>
+    <a href="../c/index.html">C</a>
+    <a href="index.html">C++</a>
+    <a href="../material/">Materialien</a>
+</nav>
 <header>
     <h1>C++ Kapitel</h1>
 </header>

--- a/cpp/kapitel-1.html
+++ b/cpp/kapitel-1.html
@@ -4,9 +4,17 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Kapitel 1: Von C zu C++ (Super-C Features)</title>
+    <link rel="preconnect" href="https://fonts.gstatic.com">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="../style.css">
 </head>
 <body>
+<nav id="main-nav">
+    <a href="../index.html">Start</a>
+    <a href="../c/index.html">C</a>
+    <a href="index.html">C++</a>
+    <a href="../material/">Materialien</a>
+</nav>
 
     <header>
         <h1>Kapitel 1: Von C zu C++ (Super-C Features)</h1>

--- a/cpp/kapitel-10.html
+++ b/cpp/kapitel-10.html
@@ -4,9 +4,17 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Kapitel 10: Nützliche Werkzeuge (Utilities)</title>
+    <link rel="preconnect" href="https://fonts.gstatic.com">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="../style.css">
 </head>
 <body>
+<nav id="main-nav">
+    <a href="../index.html">Start</a>
+    <a href="../c/index.html">C</a>
+    <a href="index.html">C++</a>
+    <a href="../material/">Materialien</a>
+</nav>
 
     <header>
         <h1>Kapitel 10: Nützliche Werkzeuge (Utilities)</h1>

--- a/cpp/kapitel-11.html
+++ b/cpp/kapitel-11.html
@@ -4,9 +4,17 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Kapitel 11: Design Patterns (Entwurfsmuster)</title>
+    <link rel="preconnect" href="https://fonts.gstatic.com">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="../style.css">
 </head>
 <body>
+<nav id="main-nav">
+    <a href="../index.html">Start</a>
+    <a href="../c/index.html">C</a>
+    <a href="index.html">C++</a>
+    <a href="../material/">Materialien</a>
+</nav>
 
     <header>
         <h1>Kapitel 11: Design Patterns (Entwurfsmuster)</h1>

--- a/cpp/kapitel-12.html
+++ b/cpp/kapitel-12.html
@@ -4,9 +4,17 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Kapitel 12: Sonstiges (Odds & Ends)</title>
+    <link rel="preconnect" href="https://fonts.gstatic.com">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="../style.css">
 </head>
 <body>
+<nav id="main-nav">
+    <a href="../index.html">Start</a>
+    <a href="../c/index.html">C</a>
+    <a href="index.html">C++</a>
+    <a href="../material/">Materialien</a>
+</nav>
 
     <header>
         <h1>Kapitel 12: Sonstiges (Odds & Ends)</h1>

--- a/cpp/kapitel-2.html
+++ b/cpp/kapitel-2.html
@@ -4,9 +4,17 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Kapitel 2: Klassen und Objekte</title>
+    <link rel="preconnect" href="https://fonts.gstatic.com">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="../style.css">
 </head>
 <body>
+<nav id="main-nav">
+    <a href="../index.html">Start</a>
+    <a href="../c/index.html">C</a>
+    <a href="index.html">C++</a>
+    <a href="../material/">Materialien</a>
+</nav>
 
     <header>
         <h1>Kapitel 2: Klassen und Objekte</h1>

--- a/cpp/kapitel-3.html
+++ b/cpp/kapitel-3.html
@@ -4,9 +4,17 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Kapitel 3: Ressourcenmanagement & Kopiersemantik</title>
+    <link rel="preconnect" href="https://fonts.gstatic.com">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="../style.css">
 </head>
 <body>
+<nav id="main-nav">
+    <a href="../index.html">Start</a>
+    <a href="../c/index.html">C</a>
+    <a href="index.html">C++</a>
+    <a href="../material/">Materialien</a>
+</nav>
 
     <header>
         <h1>Kapitel 3: Ressourcenmanagement & Kopiersemantik</h1>

--- a/cpp/kapitel-4.html
+++ b/cpp/kapitel-4.html
@@ -4,9 +4,17 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Kapitel 4: Klassen - Fortgeschrittene Konzepte</title>
+    <link rel="preconnect" href="https://fonts.gstatic.com">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="../style.css">
 </head>
 <body>
+<nav id="main-nav">
+    <a href="../index.html">Start</a>
+    <a href="../c/index.html">C</a>
+    <a href="index.html">C++</a>
+    <a href="../material/">Materialien</a>
+</nav>
 
     <header>
         <h1>Kapitel 4: Klassen - Fortgeschrittene Konzepte</h1>

--- a/cpp/kapitel-5.html
+++ b/cpp/kapitel-5.html
@@ -4,9 +4,17 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Kapitel 5: Vererbung - Grundlagen</title>
+    <link rel="preconnect" href="https://fonts.gstatic.com">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="../style.css">
 </head>
 <body>
+<nav id="main-nav">
+    <a href="../index.html">Start</a>
+    <a href="../c/index.html">C</a>
+    <a href="index.html">C++</a>
+    <a href="../material/">Materialien</a>
+</nav>
 
     <header>
         <h1>Kapitel 5: Vererbung - Grundlagen</h1>

--- a/cpp/kapitel-6.html
+++ b/cpp/kapitel-6.html
@@ -4,9 +4,17 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Kapitel 6: Polymorphie und virtuelle Funktionen</title>
+    <link rel="preconnect" href="https://fonts.gstatic.com">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="../style.css">
 </head>
 <body>
+<nav id="main-nav">
+    <a href="../index.html">Start</a>
+    <a href="../c/index.html">C</a>
+    <a href="index.html">C++</a>
+    <a href="../material/">Materialien</a>
+</nav>
 
     <header>
         <h1>Kapitel 6: Polymorphie und virtuelle Funktionen</h1>

--- a/cpp/kapitel-7.html
+++ b/cpp/kapitel-7.html
@@ -4,9 +4,17 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Kapitel 7: Operatoren überladen</title>
+    <link rel="preconnect" href="https://fonts.gstatic.com">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="../style.css">
 </head>
 <body>
+<nav id="main-nav">
+    <a href="../index.html">Start</a>
+    <a href="../c/index.html">C</a>
+    <a href="index.html">C++</a>
+    <a href="../material/">Materialien</a>
+</nav>
 
     <header>
         <h1>Kapitel 7: Operatoren überladen</h1>

--- a/cpp/kapitel-8.html
+++ b/cpp/kapitel-8.html
@@ -4,9 +4,17 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Kapitel 8: Templates</title>
+    <link rel="preconnect" href="https://fonts.gstatic.com">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="../style.css">
 </head>
 <body>
+<nav id="main-nav">
+    <a href="../index.html">Start</a>
+    <a href="../c/index.html">C</a>
+    <a href="index.html">C++</a>
+    <a href="../material/">Materialien</a>
+</nav>
 
     <header>
         <h1>Kapitel 8: Templates</h1>

--- a/cpp/kapitel-9.html
+++ b/cpp/kapitel-9.html
@@ -4,9 +4,17 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Kapitel 9: Die Standard Template Library (STL)</title>
+    <link rel="preconnect" href="https://fonts.gstatic.com">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="../style.css">
 </head>
 <body>
+<nav id="main-nav">
+    <a href="../index.html">Start</a>
+    <a href="../c/index.html">C</a>
+    <a href="index.html">C++</a>
+    <a href="../material/">Materialien</a>
+</nav>
 
     <header>
         <h1>Kapitel 9: Die Standard Template Library (STL)</h1>

--- a/index.html
+++ b/index.html
@@ -4,9 +4,17 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Lernplan: Programmieren 2 (C & C++)</title>
+    <link rel="preconnect" href="https://fonts.gstatic.com">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
+<nav id="main-nav">
+    <a href="index.html">Start</a>
+    <a href="c/index.html">C</a>
+    <a href="cpp/index.html">C++</a>
+    <a href="material/">Materialien</a>
+</nav>
 <header>
     <h1>Programmieren 2</h1>
     <p>Dein interaktiver Lernpfad für C und C++</p>

--- a/style.css
+++ b/style.css
@@ -2,13 +2,15 @@
 :root {
     --primary-color: #005A9C; /* Ein sattes Blau */
     --secondary-color: #E6F0F6; /* Ein helles Hintergrundblau */
+    --accent-color: #FF6B35; /* markante Akzentfarbe */
+    --background-gradient: linear-gradient(120deg, #f0f4fa, #e6ebf0);
     --text-color: #333;
     --border-color: #DDD;
     --shadow-color: rgba(0, 0, 0, 0.1);
 }
 
 body {
-    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
     line-height: 1.6;
     background-color: #f9f9f9;
     color: var(--text-color);
@@ -28,6 +30,8 @@ header {
     text-align: center;
     border-bottom: 2px solid var(--border-color);
     margin-bottom: 30px;
+    padding: 40px 20px;
+    background: var(--background-gradient);
 }
 
 header h1 {
@@ -58,11 +62,12 @@ main h2 {
     text-decoration: none;
     color: var(--text-color);
     transition: transform 0.2s ease, box-shadow 0.2s ease;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.05);
 }
 
 #chapter-list li a:hover {
-    transform: translateY(-5px);
-    box-shadow: 0 10px 20px var(--shadow-color);
+    transform: translateY(-4px);
+    box-shadow: 0 12px 24px rgba(0, 0, 0, 0.12);
 }
 
 #chapter-list h3 {
@@ -92,4 +97,26 @@ footer {
 .chapter-nav a {
     color: var(--primary-color);
     text-decoration: none;
+}
+
+/* Hauptnavigation */
+#main-nav {
+    display: flex;
+    justify-content: center;
+    gap: 1rem;
+    background: var(--primary-color);
+    padding: 1rem;
+    position: sticky;
+    top: 0;
+    z-index: 1000;
+}
+
+#main-nav a {
+    color: white;
+    text-decoration: none;
+    font-weight: bold;
+}
+
+#main-nav a:hover {
+    text-decoration: underline;
 }


### PR DESCRIPTION
## Summary
- enhance global styles with accent color, gradients and font
- restyle header and chapter links for a card look
- introduce sticky navigation bar across all pages
- embed Google Fonts on every page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859aa802720832fbfd21ae9e9673880