### PR TITLE
Update start page design and material link

### DIFF
--- a/c/01_Einfuehrung_Datentypen_Variablen.html
+++ b/c/01_Einfuehrung_Datentypen_Variablen.html
@@ -13,7 +13,7 @@
     <a href="../index.html">Start</a>
     <a href="index.html">C</a>
     <a href="../cpp/index.html">C++</a>
-    <a href="../material/">Materialien</a>
+    <a href="../material/index.html">Materialien</a>
 </nav>
 
     <header>

--- a/c/02_Operatoren_und_formatierte_IO.html
+++ b/c/02_Operatoren_und_formatierte_IO.html
@@ -13,7 +13,7 @@
     <a href="../index.html">Start</a>
     <a href="index.html">C</a>
     <a href="../cpp/index.html">C++</a>
-    <a href="../material/">Materialien</a>
+    <a href="../material/index.html">Materialien</a>
 </nav>
 
     <header>

--- a/c/03_Funktionen_Struktur.html
+++ b/c/03_Funktionen_Struktur.html
@@ -13,7 +13,7 @@
     <a href="../index.html">Start</a>
     <a href="index.html">C</a>
     <a href="../cpp/index.html">C++</a>
-    <a href="../material/">Materialien</a>
+    <a href="../material/index.html">Materialien</a>
 </nav>
 
     <header>

--- a/c/04_Kontrollstrukturen_Logik.html
+++ b/c/04_Kontrollstrukturen_Logik.html
@@ -13,7 +13,7 @@
     <a href="../index.html">Start</a>
     <a href="index.html">C</a>
     <a href="../cpp/index.html">C++</a>
-    <a href="../material/">Materialien</a>
+    <a href="../material/index.html">Materialien</a>
 </nav>
 
     <header>

--- a/c/05_Komplexe_Datentypen.html
+++ b/c/05_Komplexe_Datentypen.html
@@ -13,7 +13,7 @@
     <a href="../index.html">Start</a>
     <a href="index.html">C</a>
     <a href="../cpp/index.html">C++</a>
-    <a href="../material/">Materialien</a>
+    <a href="../material/index.html">Materialien</a>
 </nav>
 
     <header>

--- a/c/06_Zeiger_Grundlagen.html
+++ b/c/06_Zeiger_Grundlagen.html
@@ -13,7 +13,7 @@
     <a href="../index.html">Start</a>
     <a href="index.html">C</a>
     <a href="../cpp/index.html">C++</a>
-    <a href="../material/">Materialien</a>
+    <a href="../material/index.html">Materialien</a>
 </nav>
 
     <header>

--- a/c/07_Zeiger.Arithmetik_Dynamik.html
+++ b/c/07_Zeiger.Arithmetik_Dynamik.html
@@ -13,7 +13,7 @@
     <a href="../index.html">Start</a>
     <a href="index.html">C</a>
     <a href="../cpp/index.html">C++</a>
-    <a href="../material/">Materialien</a>
+    <a href="../material/index.html">Materialien</a>
 </nav>
 
     <header>

--- a/c/08_Zeiger_Fortgeschritten.html
+++ b/c/08_Zeiger_Fortgeschritten.html
@@ -13,7 +13,7 @@
     <a href="../index.html">Start</a>
     <a href="index.html">C</a>
     <a href="../cpp/index.html">C++</a>
-    <a href="../material/">Materialien</a>
+    <a href="../material/index.html">Materialien</a>
 </nav>
 
     <header>

--- a/c/09_Dateiverwaltung_Praeprozessor.html
+++ b/c/09_Dateiverwaltung_Praeprozessor.html
@@ -13,7 +13,7 @@
     <a href="../index.html">Start</a>
     <a href="index.html">C</a>
     <a href="../cpp/index.html">C++</a>
-    <a href="../material/">Materialien</a>
+    <a href="../material/index.html">Materialien</a>
 </nav>
 
     <header>

--- a/c/10_Modulare_Programmierung_Kommandozeile.html
+++ b/c/10_Modulare_Programmierung_Kommandozeile.html
@@ -13,7 +13,7 @@
     <a href="../index.html">Start</a>
     <a href="index.html">C</a>
     <a href="../cpp/index.html">C++</a>
-    <a href="../material/">Materialien</a>
+    <a href="../material/index.html">Materialien</a>
 </nav>
 
     <header>

--- a/c/11_Die_C-Standardbibliothek.html
+++ b/c/11_Die_C-Standardbibliothek.html
@@ -13,7 +13,7 @@
     <a href="../index.html">Start</a>
     <a href="index.html">C</a>
     <a href="../cpp/index.html">C++</a>
-    <a href="../material/">Materialien</a>
+    <a href="../material/index.html">Materialien</a>
 </nav>
 
     <header>

--- a/c/12_Threads.html
+++ b/c/12_Threads.html
@@ -13,7 +13,7 @@
     <a href="../index.html">Start</a>
     <a href="index.html">C</a>
     <a href="../cpp/index.html">C++</a>
-    <a href="../material/">Materialien</a>
+    <a href="../material/index.html">Materialien</a>
 </nav>
 
     <header>

--- a/c/13_Problemloesung_und_Tipps.html
+++ b/c/13_Problemloesung_und_Tipps.html
@@ -13,7 +13,7 @@
     <a href="../index.html">Start</a>
     <a href="index.html">C</a>
     <a href="../cpp/index.html">C++</a>
-    <a href="../material/">Materialien</a>
+    <a href="../material/index.html">Materialien</a>
 </nav>
 
     <header>

--- a/c/index.html
+++ b/c/index.html
@@ -15,7 +15,7 @@
     <a href="../index.html">Start</a>
     <a href="index.html">C</a>
     <a href="../cpp/index.html">C++</a>
-    <a href="../material/">Materialien</a>
+    <a href="../material/index.html">Materialien</a>
 </nav>
 <header>
     <h1>C Kapitel</h1>

--- a/cpp/index.html
+++ b/cpp/index.html
@@ -13,7 +13,7 @@
     <a href="../index.html">Start</a>
     <a href="../c/index.html">C</a>
     <a href="index.html">C++</a>
-    <a href="../material/">Materialien</a>
+    <a href="../material/index.html">Materialien</a>
 </nav>
 <header>
     <h1>C++ Kapitel</h1>

--- a/cpp/kapitel-1.html
+++ b/cpp/kapitel-1.html
@@ -13,7 +13,7 @@
     <a href="../index.html">Start</a>
     <a href="../c/index.html">C</a>
     <a href="index.html">C++</a>
-    <a href="../material/">Materialien</a>
+    <a href="../material/index.html">Materialien</a>
 </nav>
 
     <header>

--- a/cpp/kapitel-10.html
+++ b/cpp/kapitel-10.html
@@ -13,7 +13,7 @@
     <a href="../index.html">Start</a>
     <a href="../c/index.html">C</a>
     <a href="index.html">C++</a>
-    <a href="../material/">Materialien</a>
+    <a href="../material/index.html">Materialien</a>
 </nav>
 
     <header>

--- a/cpp/kapitel-11.html
+++ b/cpp/kapitel-11.html
@@ -13,7 +13,7 @@
     <a href="../index.html">Start</a>
     <a href="../c/index.html">C</a>
     <a href="index.html">C++</a>
-    <a href="../material/">Materialien</a>
+    <a href="../material/index.html">Materialien</a>
 </nav>
 
     <header>

--- a/cpp/kapitel-12.html
+++ b/cpp/kapitel-12.html
@@ -13,7 +13,7 @@
     <a href="../index.html">Start</a>
     <a href="../c/index.html">C</a>
     <a href="index.html">C++</a>
-    <a href="../material/">Materialien</a>
+    <a href="../material/index.html">Materialien</a>
 </nav>
 
     <header>

--- a/cpp/kapitel-2.html
+++ b/cpp/kapitel-2.html
@@ -13,7 +13,7 @@
     <a href="../index.html">Start</a>
     <a href="../c/index.html">C</a>
     <a href="index.html">C++</a>
-    <a href="../material/">Materialien</a>
+    <a href="../material/index.html">Materialien</a>
 </nav>
 
     <header>

--- a/cpp/kapitel-3.html
+++ b/cpp/kapitel-3.html
@@ -13,7 +13,7 @@
     <a href="../index.html">Start</a>
     <a href="../c/index.html">C</a>
     <a href="index.html">C++</a>
-    <a href="../material/">Materialien</a>
+    <a href="../material/index.html">Materialien</a>
 </nav>
 
     <header>

--- a/cpp/kapitel-4.html
+++ b/cpp/kapitel-4.html
@@ -13,7 +13,7 @@
     <a href="../index.html">Start</a>
     <a href="../c/index.html">C</a>
     <a href="index.html">C++</a>
-    <a href="../material/">Materialien</a>
+    <a href="../material/index.html">Materialien</a>
 </nav>
 
     <header>

--- a/cpp/kapitel-5.html
+++ b/cpp/kapitel-5.html
@@ -13,7 +13,7 @@
     <a href="../index.html">Start</a>
     <a href="../c/index.html">C</a>
     <a href="index.html">C++</a>
-    <a href="../material/">Materialien</a>
+    <a href="../material/index.html">Materialien</a>
 </nav>
 
     <header>

--- a/cpp/kapitel-6.html
+++ b/cpp/kapitel-6.html
@@ -13,7 +13,7 @@
     <a href="../index.html">Start</a>
     <a href="../c/index.html">C</a>
     <a href="index.html">C++</a>
-    <a href="../material/">Materialien</a>
+    <a href="../material/index.html">Materialien</a>
 </nav>
 
     <header>

--- a/cpp/kapitel-7.html
+++ b/cpp/kapitel-7.html
@@ -13,7 +13,7 @@
     <a href="../index.html">Start</a>
     <a href="../c/index.html">C</a>
     <a href="index.html">C++</a>
-    <a href="../material/">Materialien</a>
+    <a href="../material/index.html">Materialien</a>
 </nav>
 
     <header>

--- a/cpp/kapitel-8.html
+++ b/cpp/kapitel-8.html
@@ -13,7 +13,7 @@
     <a href="../index.html">Start</a>
     <a href="../c/index.html">C</a>
     <a href="index.html">C++</a>
-    <a href="../material/">Materialien</a>
+    <a href="../material/index.html">Materialien</a>
 </nav>
 
     <header>

--- a/cpp/kapitel-9.html
+++ b/cpp/kapitel-9.html
@@ -13,7 +13,7 @@
     <a href="../index.html">Start</a>
     <a href="../c/index.html">C</a>
     <a href="index.html">C++</a>
-    <a href="../material/">Materialien</a>
+    <a href="../material/index.html">Materialien</a>
 </nav>
 
     <header>

--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
     <a href="index.html">Start</a>
     <a href="c/index.html">C</a>
     <a href="cpp/index.html">C++</a>
-    <a href="material/">Materialien</a>
+    <a href="material/index.html">Materialien</a>
 </nav>
 <header>
     <h1>Programmieren 2</h1>
@@ -22,7 +22,7 @@
 <main>
 <section id="toc-c">
   <h2>Themenübersicht - Teil 1: C</h2>
-  <ul>
+  <ul class="chapter-list">
     <li>
       <a href="c/01_Einfuehrung_Datentypen_Variablen.html">
         <h3>Kapitel 1: Einführung in C: Datentypen, Variablen & Konstanten</h3>
@@ -105,7 +105,7 @@
 </section>
 <section id="toc-cpp">
   <h2>Themenübersicht - Teil 2: C++</h2>
-  <ul>
+  <ul class="chapter-list">
     <li>
       <a href="cpp/kapitel-1.html">
         <h3>Kapitel 1: Von C zu C++ (Super-C Features)</h3>
@@ -182,7 +182,7 @@
 </section>
     <section id="pdf-downloads">
         <h2>PDF-Materialien</h2>
-        <p>Alle Foliensätze und Übungsblätter findest du im <a href="material/">Ordner material</a>.</p>
+        <p>Alle Foliensätze und Übungsblätter findest du im <a href="material/index.html">Ordner material</a>.</p>
     </section>
 </main>
 <footer>

--- a/material/index.html
+++ b/material/index.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Materialien</title>
+    <link rel="stylesheet" href="../style.css">
+</head>
+<body>
+<nav id="main-nav">
+    <a href="../index.html">Start</a>
+    <a href="../c/index.html">C</a>
+    <a href="../cpp/index.html">C++</a>
+    <a href="index.html">Materialien</a>
+</nav>
+<header>
+    <h1>Materialien</h1>
+</header>
+<main>
+  <ul class="chapter-list">
+    <li><a href="c/">Materialien zu C</a></li>
+    <li><a href="cpp/">Materialien zu C++</a></li>
+  </ul>
+  <p><a href="../index.html">&larr; Zurück zur Übersicht</a></p>
+</main>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -47,12 +47,14 @@ main h2 {
 }
 
 /* Kapitel-Liste */
-#chapter-list {
+#chapter-list,
+.chapter-list {
     list-style-type: none;
     padding: 0;
 }
 
-#chapter-list li a {
+#chapter-list li a,
+.chapter-list li a {
     display: block;
     background-color: #fff;
     border: 1px solid var(--border-color);
@@ -65,16 +67,17 @@ main h2 {
     box-shadow: 0 2px 6px rgba(0, 0, 0, 0.05);
 }
 
-#chapter-list li a:hover {
+#chapter-list li a:hover,
+.chapter-list li a:hover {
     transform: translateY(-4px);
     box-shadow: 0 12px 24px rgba(0, 0, 0, 0.12);
 }
-
+.chapter-list h3,
 #chapter-list h3 {
     margin: 0 0 5px 0;
     color: var(--primary-color);
 }
-
+.chapter-list p,
 #chapter-list p {
     margin: 0;
     font-size: 0.9em;


### PR DESCRIPTION
## Summary
- ensure navigation links to `material/index.html`
- apply consistent chapter list styling and use `.chapter-list`
- add dedicated index page listing PDFs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685a5855ae4c832f8bb11a0096e5e445