### PR TITLE
Fix dark mode toggle and add button everywhere

### DIFF
--- a/c/01_Einfuehrung_Datentypen_Variablen.html
+++ b/c/01_Einfuehrung_Datentypen_Variablen.html
@@ -14,6 +14,7 @@
     <a href="index.html">C</a>
     <a href="../cpp/index.html">C++</a>
     <a href="../material/index.html">Materialien</a>
+    <button id="theme-toggle" aria-label="Theme umschalten">🌓</button>
 </nav>
 
     <header>
@@ -315,5 +316,6 @@ printf("Text...");
         <p>&copy; 2025 - Dein persönlicher Programmier-Tutor</p>
     </footer>
 
+<script src="../toggleTheme.js"></script>
 </body>
 </html>

--- a/c/02_Operatoren_und_formatierte_IO.html
+++ b/c/02_Operatoren_und_formatierte_IO.html
@@ -14,6 +14,7 @@
     <a href="index.html">C</a>
     <a href="../cpp/index.html">C++</a>
     <a href="../material/index.html">Materialien</a>
+    <button id="theme-toggle" aria-label="Theme umschalten">🌓</button>
 </nav>
 
     <header>
@@ -306,5 +307,6 @@ scanf(" %c", &c); // char (mit Leerzeichen davor, um Whitespace zu ignorieren)
         <p>&copy; 2025 - Dein persönlicher Programmier-Tutor</p>
     </footer>
 
+<script src="../toggleTheme.js"></script>
 </body>
 </html>

--- a/c/03_Funktionen_Struktur.html
+++ b/c/03_Funktionen_Struktur.html
@@ -14,6 +14,7 @@
     <a href="index.html">C</a>
     <a href="../cpp/index.html">C++</a>
     <a href="../material/index.html">Materialien</a>
+    <button id="theme-toggle" aria-label="Theme umschalten">🌓</button>
 </nav>
 
     <header>
@@ -330,5 +331,6 @@ void anotherFunc() {
         <p>&copy; 2025 - Dein persönlicher Programmier-Tutor</p>
     </footer>
 
+<script src="../toggleTheme.js"></script>
 </body>
 </html>

--- a/c/04_Kontrollstrukturen_Logik.html
+++ b/c/04_Kontrollstrukturen_Logik.html
@@ -14,6 +14,7 @@
     <a href="index.html">C</a>
     <a href="../cpp/index.html">C++</a>
     <a href="../material/index.html">Materialien</a>
+    <button id="theme-toggle" aria-label="Theme umschalten">🌓</button>
 </nav>
 
     <header>
@@ -328,5 +329,6 @@ Rueckgabetyp RecursiveFunc(Parameter p) {
         <p>&copy; 2025 - Dein persönlicher Programmier-Tutor</p>
     </footer>
 
+<script src="../toggleTheme.js"></script>
 </body>
 </html>

--- a/c/05_Komplexe_Datentypen.html
+++ b/c/05_Komplexe_Datentypen.html
@@ -14,6 +14,7 @@
     <a href="index.html">C</a>
     <a href="../cpp/index.html">C++</a>
     <a href="../material/index.html">Materialien</a>
+    <button id="theme-toggle" aria-label="Theme umschalten">🌓</button>
 </nav>
 
     <header>
@@ -301,5 +302,6 @@ strcpy_s(library[0].title, 100, "C Fibel");
         <p>&copy; 2025 - Dein persönlicher Programmier-Tutor</p>
     </footer>
 
+<script src="../toggleTheme.js"></script>
 </body>
 </html>

--- a/c/06_Zeiger_Grundlagen.html
+++ b/c/06_Zeiger_Grundlagen.html
@@ -14,6 +14,7 @@
     <a href="index.html">C</a>
     <a href="../cpp/index.html">C++</a>
     <a href="../material/index.html">Materialien</a>
+    <button id="theme-toggle" aria-label="Theme umschalten">🌓</button>
 </nav>
 
     <header>
@@ -288,5 +289,6 @@ p_point->x = 5; // Pfeiloperator
         <p>&copy; 2025 - Dein persönlicher Programmier-Tutor</p>
     </footer>
 
+<script src="../toggleTheme.js"></script>
 </body>
 </html>

--- a/c/07_Zeiger.Arithmetik_Dynamik.html
+++ b/c/07_Zeiger.Arithmetik_Dynamik.html
@@ -14,6 +14,7 @@
     <a href="index.html">C</a>
     <a href="../cpp/index.html">C++</a>
     <a href="../material/index.html">Materialien</a>
+    <button id="theme-toggle" aria-label="Theme umschalten">🌓</button>
 </nav>
 
     <header>
@@ -285,5 +286,6 @@ p_mem = NULL;
         <p>&copy; 2025 - Dein persönlicher Programmier-Tutor</p>
     </footer>
 
+<script src="../toggleTheme.js"></script>
 </body>
 </html>

--- a/c/08_Zeiger_Fortgeschritten.html
+++ b/c/08_Zeiger_Fortgeschritten.html
@@ -14,6 +14,7 @@
     <a href="index.html">C</a>
     <a href="../cpp/index.html">C++</a>
     <a href="../material/index.html">Materialien</a>
+    <button id="theme-toggle" aria-label="Theme umschalten">🌓</button>
 </nav>
 
     <header>
@@ -296,5 +297,6 @@ int my_compare(const void* a, const void* b) {
         <p>&copy; 2025 - Dein persönlicher Programmier-Tutor</p>
     </footer>
 
+<script src="../toggleTheme.js"></script>
 </body>
 </html>

--- a/c/09_Dateiverwaltung_Praeprozessor.html
+++ b/c/09_Dateiverwaltung_Praeprozessor.html
@@ -14,6 +14,7 @@
     <a href="index.html">C</a>
     <a href="../cpp/index.html">C++</a>
     <a href="../material/index.html">Materialien</a>
+    <button id="theme-toggle" aria-label="Theme umschalten">🌓</button>
 </nav>
 
     <header>
@@ -304,5 +305,6 @@ if (err == 0 && p_f != NULL) {
         <p>&copy; 2025 - Dein persönlicher Programmier-Tutor</p>
     </footer>
 
+<script src="../toggleTheme.js"></script>
 </body>
 </html>

--- a/c/10_Modulare_Programmierung_Kommandozeile.html
+++ b/c/10_Modulare_Programmierung_Kommandozeile.html
@@ -14,6 +14,7 @@
     <a href="index.html">C</a>
     <a href="../cpp/index.html">C++</a>
     <a href="../material/index.html">Materialien</a>
+    <button id="theme-toggle" aria-label="Theme umschalten">🌓</button>
 </nav>
 
     <header>
@@ -190,5 +191,6 @@ int main(void) {
         <p>&copy; 2025 - Dein persönlicher Programmier-Tutor</p>
     </footer>
 
+<script src="../toggleTheme.js"></script>
 </body>
 </html>

--- a/c/11_Die_C-Standardbibliothek.html
+++ b/c/11_Die_C-Standardbibliothek.html
@@ -14,6 +14,7 @@
     <a href="index.html">C</a>
     <a href="../cpp/index.html">C++</a>
     <a href="../material/index.html">Materialien</a>
+    <button id="theme-toggle" aria-label="Theme umschalten">🌓</button>
 </nav>
 
     <header>
@@ -257,5 +258,6 @@ double duration = ((double)(end-start))/CLOCKS_PER_SEC;
         <p>&copy; 2025 - Dein persönlicher Programmier-Tutor</p>
     </footer>
 
+<script src="../toggleTheme.js"></script>
 </body>
 </html>

--- a/c/12_Threads.html
+++ b/c/12_Threads.html
@@ -14,6 +14,7 @@
     <a href="index.html">C</a>
     <a href="../cpp/index.html">C++</a>
     <a href="../material/index.html">Materialien</a>
+    <button id="theme-toggle" aria-label="Theme umschalten">🌓</button>
 </nav>
 
     <header>
@@ -301,5 +302,6 @@ ReleaseMutex(hMutex);
         <p>&copy; 2025 - Dein persönlicher Programmier-Tutor</p>
     </footer>
 
+<script src="../toggleTheme.js"></script>
 </body>
 </html>

--- a/c/13_Problemloesung_und_Tipps.html
+++ b/c/13_Problemloesung_und_Tipps.html
@@ -14,6 +14,7 @@
     <a href="index.html">C</a>
     <a href="../cpp/index.html">C++</a>
     <a href="../material/index.html">Materialien</a>
+    <button id="theme-toggle" aria-label="Theme umschalten">🌓</button>
 </nav>
 
     <header>
@@ -251,5 +252,6 @@ while ((temp_char = getchar()) != '\n' && temp_char != EOF);
         <p>&copy; 2025 - Dein persönlicher Programmier-Tutor</p>
     </footer>
 
+<script src="../toggleTheme.js"></script>
 </body>
 </html>

--- a/cpp/kapitel-1.html
+++ b/cpp/kapitel-1.html
@@ -14,6 +14,7 @@
     <a href="../c/index.html">C</a>
     <a href="index.html">C++</a>
     <a href="../material/index.html">Materialien</a>
+    <button id="theme-toggle" aria-label="Theme umschalten">🌓</button>
 </nav>
 
     <header>
@@ -286,5 +287,6 @@ T func(T param) { /* ... */ }
         <p>&copy; 2025 - Dein persönlicher Programmier-Tutor</p>
     </footer>
 
+<script src="../toggleTheme.js"></script>
 </body>
 </html>

--- a/cpp/kapitel-10.html
+++ b/cpp/kapitel-10.html
@@ -14,6 +14,7 @@
     <a href="../c/index.html">C</a>
     <a href="index.html">C++</a>
     <a href="../material/index.html">Materialien</a>
+    <button id="theme-toggle" aria-label="Theme umschalten">🌓</button>
 </nav>
 
     <header>
@@ -175,5 +176,6 @@ int main() {
 <p><a href="../index.html">&larr; Zurück zur Übersicht</a></p>
         <p>&copy; 2025 - Dein persönlicher Programmier-Tutor</p>
     </footer>
+<script src="../toggleTheme.js"></script>
 </body>
 </html>

--- a/cpp/kapitel-11.html
+++ b/cpp/kapitel-11.html
@@ -14,6 +14,7 @@
     <a href="../c/index.html">C</a>
     <a href="index.html">C++</a>
     <a href="../material/index.html">Materialien</a>
+    <button id="theme-toggle" aria-label="Theme umschalten">🌓</button>
 </nav>
 
     <header>
@@ -191,5 +192,6 @@ public:
 <p><a href="../index.html">&larr; Zurück zur Übersicht</a></p>
         <p>&copy; 2025 - Dein persönlicher Programmier-Tutor</p>
     </footer>
+<script src="../toggleTheme.js"></script>
 </body>
 </html>

--- a/cpp/kapitel-12.html
+++ b/cpp/kapitel-12.html
@@ -14,6 +14,7 @@
     <a href="../c/index.html">C</a>
     <a href="index.html">C++</a>
     <a href="../material/index.html">Materialien</a>
+    <button id="theme-toggle" aria-label="Theme umschalten">🌓</button>
 </nav>
 
     <header>
@@ -174,5 +175,6 @@ int main() {
 <p><a href="../index.html">&larr; Zurück zur Übersicht</a></p>
         <p>&copy; 2025 - Dein persönlicher Programmier-Tutor</p>
     </footer>
+<script src="../toggleTheme.js"></script>
 </body>
 </html>

--- a/cpp/kapitel-2.html
+++ b/cpp/kapitel-2.html
@@ -14,6 +14,7 @@
     <a href="../c/index.html">C</a>
     <a href="index.html">C++</a>
     <a href="../material/index.html">Materialien</a>
+    <button id="theme-toggle" aria-label="Theme umschalten">🌓</button>
 </nav>
 
     <header>
@@ -316,5 +317,6 @@ delete p_obj2;
         <p>&copy; 2025 - Dein persönlicher Programmier-Tutor</p>
     </footer>
 
+<script src="../toggleTheme.js"></script>
 </body>
 </html>

--- a/cpp/kapitel-3.html
+++ b/cpp/kapitel-3.html
@@ -14,6 +14,7 @@
     <a href="../c/index.html">C</a>
     <a href="index.html">C++</a>
     <a href="../material/index.html">Materialien</a>
+    <button id="theme-toggle" aria-label="Theme umschalten">🌓</button>
 </nav>
 
     <header>
@@ -177,5 +178,6 @@ z3.vPrint(); // Gibt "4 + j(2)" aus
 </nav>
 <p><a href="../index.html">&larr; Zurück zur Übersicht</a></p>
     </footer>
+<script src="../toggleTheme.js"></script>
 </body>
 </html>

--- a/cpp/kapitel-4.html
+++ b/cpp/kapitel-4.html
@@ -14,6 +14,7 @@
     <a href="../c/index.html">C</a>
     <a href="index.html">C++</a>
     <a href="../material/index.html">Materialien</a>
+    <button id="theme-toggle" aria-label="Theme umschalten">🌓</button>
 </nav>
 
     <header>
@@ -188,5 +189,6 @@ int main() {
 <p><a href="../index.html">&larr; Zurück zur Übersicht</a></p>
         <p>&copy; 2025 - Dein persönlicher Programmier-Tutor</p>
     </footer>
+<script src="../toggleTheme.js"></script>
 </body>
 </html>

--- a/cpp/kapitel-5.html
+++ b/cpp/kapitel-5.html
@@ -14,6 +14,7 @@
     <a href="../c/index.html">C</a>
     <a href="index.html">C++</a>
     <a href="../material/index.html">Materialien</a>
+    <button id="theme-toggle" aria-label="Theme umschalten">🌓</button>
 </nav>
 
     <header>
@@ -195,5 +196,6 @@ int main() {
 <p><a href="../index.html">&larr; Zurück zur Übersicht</a></p>
         <p>&copy; 2025 - Dein persönlicher Programmier-Tutor</p>
     </footer>
+<script src="../toggleTheme.js"></script>
 </body>
 </html>

--- a/cpp/kapitel-6.html
+++ b/cpp/kapitel-6.html
@@ -14,6 +14,7 @@
     <a href="../c/index.html">C</a>
     <a href="index.html">C++</a>
     <a href="../material/index.html">Materialien</a>
+    <button id="theme-toggle" aria-label="Theme umschalten">🌓</button>
 </nav>
 
     <header>
@@ -184,5 +185,6 @@ delete b; // Ruft ~Derived() und DANACH ~Base() auf. Alles korrekt.
 <p><a href="../index.html">&larr; Zurück zur Übersicht</a></p>
         <p>&copy; 2025 - Dein persönlicher Programmier-Tutor</p>
     </footer>
+<script src="../toggleTheme.js"></script>
 </body>
 </html>

--- a/cpp/kapitel-7.html
+++ b/cpp/kapitel-7.html
@@ -14,6 +14,7 @@
     <a href="../c/index.html">C</a>
     <a href="index.html">C++</a>
     <a href="../material/index.html">Materialien</a>
+    <button id="theme-toggle" aria-label="Theme umschalten">🌓</button>
 </nav>
 
     <header>
@@ -172,5 +173,6 @@ public:
 <p><a href="../index.html">&larr; Zurück zur Übersicht</a></p>
         <p>&copy; 2025 - Dein persönlicher Programmier-Tutor</p>
     </footer>
+<script src="../toggleTheme.js"></script>
 </body>
 </html>

--- a/cpp/kapitel-8.html
+++ b/cpp/kapitel-8.html
@@ -14,6 +14,7 @@
     <a href="../c/index.html">C</a>
     <a href="index.html">C++</a>
     <a href="../material/index.html">Materialien</a>
+    <button id="theme-toggle" aria-label="Theme umschalten">🌓</button>
 </nav>
 
     <header>
@@ -170,5 +171,6 @@ int main() {
 <p><a href="../index.html">&larr; Zurück zur Übersicht</a></p>
         <p>&copy; 2025 - Dein persönlicher Programmier-Tutor</p>
     </footer>
+<script src="../toggleTheme.js"></script>
 </body>
 </html>

--- a/cpp/kapitel-9.html
+++ b/cpp/kapitel-9.html
@@ -14,6 +14,7 @@
     <a href="../c/index.html">C</a>
     <a href="index.html">C++</a>
     <a href="../material/index.html">Materialien</a>
+    <button id="theme-toggle" aria-label="Theme umschalten">🌓</button>
 </nav>
 
     <header>
@@ -183,5 +184,6 @@ int main() {
 <p><a href="../index.html">&larr; Zurück zur Übersicht</a></p>
         <p>&copy; 2025 - Dein persönlicher Programmier-Tutor</p>
     </footer>
+<script src="../toggleTheme.js"></script>
 </body>
 </html>

--- a/material/index.html
+++ b/material/index.html
@@ -12,6 +12,7 @@
     <a href="../c/index.html">C</a>
     <a href="../cpp/index.html">C++</a>
     <a href="index.html">Materialien</a>
+    <button id="theme-toggle" aria-label="Theme umschalten">🌓</button>
 </nav>
 <header>
     <h1>Materialien</h1>
@@ -23,5 +24,6 @@
   </ul>
   <p><a href="../index.html">&larr; Zurück zur Übersicht</a></p>
 </main>
+<script src="../toggleTheme.js"></script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -173,3 +173,25 @@ body.dark #main-nav {
 body.dark a {
     color: #9cd2ff;
 }
+body.light {
+    background-color: #f9f9f9;
+    color: var(--text-color);
+}
+body.light header {
+    background: var(--background-gradient);
+}
+body.light main,
+body.light footer {
+    background-color: transparent;
+}
+body.light #chapter-list li a,
+body.light .chapter-list li a {
+    background-color: #fff;
+    border-color: var(--border-color);
+}
+body.light #main-nav {
+    background: var(--primary-color);
+}
+body.light a {
+    color: var(--primary-color);
+}

--- a/toggleTheme.js
+++ b/toggleTheme.js
@@ -4,9 +4,16 @@ window.addEventListener('DOMContentLoaded', () => {
     const saved = localStorage.getItem('theme');
     if (saved === 'dark') {
         document.body.classList.add('dark');
+    } else if (saved === 'light') {
+        document.body.classList.add('light');
     }
     btn.addEventListener('click', () => {
-        document.body.classList.toggle('dark');
-        localStorage.setItem('theme', document.body.classList.contains('dark') ? 'dark' : 'light');
+        const nowDark = document.body.classList.toggle('dark');
+        if (nowDark) {
+            document.body.classList.remove('light');
+        } else {
+            document.body.classList.add('light');
+        }
+        localStorage.setItem('theme', nowDark ? 'dark' : 'light');
     });
 });


### PR DESCRIPTION
## Summary
- add `.light` mode CSS to override OS dark scheme
- improve theme toggle script to handle light and dark states
- include dark mode toggle button and script on all content pages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a6755413c832fabc83a15820713ad