### PR TITLE
Remove automatic OS dark mode

### DIFF
--- a/style.css
+++ b/style.css
@@ -131,27 +131,6 @@ footer {
     cursor: pointer;
     font-size: 1rem;
 }
-/* Dark Mode */
-@media (prefers-color-scheme: dark) {
-    body {
-        background-color: #121212;
-        color: #e0e0e0;
-    }
-    header, main, footer {
-        background-color: #1e1e1e;
-    }
-    #chapter-list li a,
-    .chapter-list li a {
-        background-color: #1e1e1e;
-        border-color: #333;
-    }
-    #main-nav {
-        background: #333;
-    }
-    a {
-        color: #9cd2ff;
-    }
-}
 
 body.dark {
     background-color: #121212;

--- a/toggleTheme.js
+++ b/toggleTheme.js
@@ -4,7 +4,7 @@ window.addEventListener('DOMContentLoaded', () => {
     const saved = localStorage.getItem('theme');
     if (saved === 'dark') {
         document.body.classList.add('dark');
-    } else if (saved === 'light') {
+    } else {
         document.body.classList.add('light');
     }
     btn.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- remove prefers-color-scheme css rules so dark mode only toggles via button
- default to light theme when no setting is stored

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a692925ac832f87d5355576824511